### PR TITLE
feat: 409 에러 메시지 추가를 위한 예외처리 핸들러 추가

### DIFF
--- a/src/main/java/com/jnu/projectlab/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/jnu/projectlab/exception/GlobalExceptionHandler.java
@@ -1,0 +1,23 @@
+// 새로운 파일: GlobalExceptionHandler.java
+package com.jnu.projectlab.exception;
+
+import com.jnu.projectlab.user.DuplicatedUserException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(DuplicatedUserException.class)
+    public ResponseEntity<Object> handleDuplicatedUserException(DuplicatedUserException ex) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("message", ex.getMessage());
+
+        return new ResponseEntity<>(body, HttpStatus.CONFLICT); // 409 상태 코드 추가
+    }
+}

--- a/src/main/java/com/jnu/projectlab/user/DuplicatedUserException.java
+++ b/src/main/java/com/jnu/projectlab/user/DuplicatedUserException.java
@@ -1,0 +1,8 @@
+// 새로운 파일: DuplicatedUserException.java
+package com.jnu.projectlab.user;
+
+public class DuplicatedUserException extends RuntimeException {
+    public DuplicatedUserException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
예외처리를 추가하여 계정중복일 경우 409 에러 메시지가 출력되도록 했습니다.