### PR TITLE
feat: 날짜/시간 변환을 위한 DateUtils 유틸리티 클래스 추가

### DIFF
--- a/src/main/java/com/jnu/projectlab/common/util/DateUtils.java
+++ b/src/main/java/com/jnu/projectlab/common/util/DateUtils.java
@@ -1,0 +1,49 @@
+package com.jnu.projectlab.common.util;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+public class DateUtils {
+
+    // 날짜 포맷: YYYYMMDD
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    // 날짜시간 포맷: YYYY-MM-DD HH:mm:ss
+    private static final DateTimeFormatter DATETIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    /**
+     * YYYYMMDD 형식 문자열을 LocalDate로 변환
+     * 예: "20250529" → LocalDate
+     */
+    public static LocalDate parseDate(String dateString) {
+        if (dateString == null || dateString.trim().isEmpty()) {
+            return null;
+        }
+
+        try {
+            return LocalDate.parse(dateString.trim(), DATE_FORMATTER);
+        } catch (DateTimeParseException e) {
+            // 파싱 실패 시 null 반환 (로그는 선택사항)
+            return null;
+        }
+    }
+
+    /**
+     * YYYY-MM-DD HH:mm:ss 형식 문자열을 LocalDateTime으로 변환
+     * 예: "2025-05-29 11:19:09" → LocalDateTime
+     */
+    public static LocalDateTime parseDateTime(String dateTimeString) {
+        if (dateTimeString == null || dateTimeString.trim().isEmpty()) {
+            return null;
+        }
+
+        try {
+            return LocalDateTime.parse(dateTimeString.trim(), DATETIME_FORMATTER);
+        } catch (DateTimeParseException e) {
+            // 파싱 실패 시 null 반환 (로그는 선택사항)
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
기능 1: parseDate() - 8자리 날짜 문자열을 LocalDate 객체로 변환
- 입력: "20250529" (문자열)
- 출력: LocalDate.of(2025, 5, 29) (Java LocalDate 객체)
- 잘못된 값이나 빈값이면 null 반환

기능 2: parseDateTime() - 날짜시간 문자열을 LocalDateTime 객체로 변환
- 입력: "2025-05-29 11:19:09" (문자열)
- 출력: LocalDateTime.of(2025, 5, 29, 11, 19, 9) (Java LocalDateTime 객체)
- 형식이 틀려도 앱이 죽지 않고 null 반환

@yunsammy 파싱되는 정보라서 따로 올려놓았습니다. 






_**features/common from common/datautils**_