### PR TITLE
feat: 정책 데이터 배치 로딩 컨트롤러 구현 [배치 부문]

### DIFF
--- a/src/main/java/com/jnu/projectlab/batch/controller/PolicyDataLoadController.java
+++ b/src/main/java/com/jnu/projectlab/batch/controller/PolicyDataLoadController.java
@@ -1,0 +1,29 @@
+package com.jnu.projectlab.batch.controller;
+
+import com.jnu.projectlab.batch.service.PolicyDataLoadService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/policy")
+@RequiredArgsConstructor
+public class PolicyDataLoadController {
+
+    private final PolicyDataLoadService policyDataLoadService;
+
+    @PostMapping("/load")
+    public ResponseEntity<String> loadPolicyData() {
+        try {
+            policyDataLoadService.loadPolicyData();
+            return ResponseEntity.ok("정책 데이터 적재 완료!");
+        } catch (Exception e) {
+            log.error("정책 데이터 적재 중 에러 발생", e);
+            return ResponseEntity.internalServerError().body("에러: " + e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
PolicyDataLoadController:
- POST /api/policy/load 엔드포인트 추가
- 입력: HTTP POST 요청 (파라미터 없음)
- 출력: 성공 시 "정책 데이터 적재 완료!" / 실패 시 에러 메시지
- PolicyDataLoadService 호출하여 실제 배치 작업 수행

기능:
- all_policy_data.json에서 정책 데이터를 가져와 DB에 저장하는 수동 트리거
- 예외 발생 시 로그 기록 및 HTTP 500 응답 반환
- 배치 작업 상태를 사용자에게 즉시 피드백
- @yunsammy 리뷰 부탁드립니다