### PR TITLE
fix: Add field 운영기관코드

### DIFF
--- a/src/main/java/com/jnu/projectlab/policy/entity/Policy.java
+++ b/src/main/java/com/jnu/projectlab/policy/entity/Policy.java
@@ -110,4 +110,7 @@ public class Policy {
     @UpdateTimestamp
     @Column(name = "last_modified_at")
     private LocalDateTime lastModifiedAt; // 최종수정일시
+
+    @Column(name = "oper_inst_cd")
+    private String operInstCd; // 운영기관코드 (Organization의 PK와 매핑되는 외래키 역할)
 }


### PR DESCRIPTION
Organization의 PK와 매핑되는 외래키 역할을 하기위해서 추가했습니다. 제가 실수로 policy에 안 넣어놨더라고요!