### PR TITLE
[#93] Docker 기반 배포 환경 설정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# 1️⃣ Build Stage
+FROM gradle:8.5-jdk17 AS builder
+WORKDIR /app
+COPY . .
+RUN gradle clean bootJar -x test
+
+# 2️⃣ Runtime Stage
+FROM eclipse-temurin:17-jdk
+WORKDIR /app
+RUN mkdir -p /logs && chmod 777 /logs
+
+COPY --from=builder /app/build/libs/*.jar app.jar
+
+EXPOSE 8080
+
+# 표준 출력/에러 로그 분리 저장
+ENTRYPOINT ["sh", "-c", "java -jar /app/app.jar > /logs/app.out.log 2> /logs/app.err.log"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+services:
+  db:
+    image: postgres:latest
+    container_name: timing-db
+    restart: always
+    environment:
+      POSTGRES_USER: ${DATABASE_USERNAME}
+      POSTGRES_PASSWORD: ${DATABASE_PASSWORD}
+      POSTGRES_DB: timing
+    volumes:
+      - ./postgres:/var/lib/postgresql
+    ports:
+      - "5432:5432"
+
+  backend:
+    build: .
+    container_name: timing-be
+    restart: always
+    depends_on:
+      - db
+    env_file:
+      - .env
+    volumes:
+      - ./logs:/logs
+    ports:
+      - "8080:8080"
+
+volumes:
+  db_data:


### PR DESCRIPTION
# 작업 내용
- close #93
  - Dockerfile 및 docker-compose를 이용한 백엔드, DB 통합 컨테이너 환경 구성
- GCP 서버 배포 완료

# 이슈
- Nginx도 같은 서버에 올리려고 했으나, ssl 이슈 때문에 다른 서버에 올려 Reverse Proxy 형태로 사용하도록 함